### PR TITLE
Fix artifact build trigger

### DIFF
--- a/.github/workflows/do-release.yml
+++ b/.github/workflows/do-release.yml
@@ -1,9 +1,9 @@
 name: Publish artifacts on release
 
 on:
-  push:
-    tags:
-      - v*
+  release:
+    types:
+      - released
 
 jobs:
   release-executable-jar:


### PR DESCRIPTION
Artifact builds were triggering on tag push rather than release publication. This fixes that.