### PR TITLE
Update arguments for artifact publishing process

### DIFF
--- a/.github/workflows/do-release.yml
+++ b/.github/workflows/do-release.yml
@@ -30,8 +30,7 @@ jobs:
       - uses: Roang-zero1/github-upload-release-artifacts-action@2.1.0
         name: Upload JAR file to release
         with:
-          args:
-            - build/libs/
+          args: "build/libs/"
         env:
           GITHUB_TOKEN: ${{ github.token }}
 


### PR DESCRIPTION
We were using an invalid configuration for the artifact publishing step. This should fix the workflow and make it valid.